### PR TITLE
add tensorboard support

### DIFF
--- a/pyscript/index.py
+++ b/pyscript/index.py
@@ -1,13 +1,16 @@
 import tensorflow as tf
 import sys
 
-def train(xs, ys, model, j, batchesPerEpoch):
+def train(xs, ys, model, j, batchesPerEpoch, trainSummaryWriter, iteration):
   xs = tf.stack(xs)
   ys = tf.stack(ys)
   trainRes = model.train_on_batch(xs, ys)
   if (j % (int(batchesPerEpoch / 10)) == 0):
     print('Iteration {}/{} result --- loss: {} accuracy: {}'.format(j, batchesPerEpoch, trainRes[0], trainRes[1]))
   sys.stdout.flush()
+  with trainSummaryWriter.as_default():
+    tf.summary.scalar('loss', trainRes[0], step=iteration)
+    tf.summary.scalar('accuracy', trainRes[1], step=iteration)
 
   
 def evaluate(xs, ys, model):

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,9 @@ const ModelTrain: ModelTrainType = async (data: ImageDataset, model: UniModel, a
     modelPath
   } = args;
 
+  // create tf summary writter
+  const trainSummaryWriter = tf.summary.create_file_writter(path.join(modelPath, 'summary'));
+
   const { trainLoader, validationLoader } = data;
   const count = await trainLoader.len();
   let valBatchesPerEpoch: number;
@@ -41,11 +44,12 @@ const ModelTrain: ModelTrainType = async (data: ImageDataset, model: UniModel, a
   const batchesPerEpoch = Math.floor(count / batchSize);
   const trainModel = model.model;
 
+  let iterations = 0;
   for (let i = 0; i < epochs; i++) {
     console.log(`Epoch ${i}/${epochs} start`);
     for (let j = 0; j < batchesPerEpoch; j++) {
       const dataBatch = await data.trainLoader.nextBatch(batchSize);
-      train(dataBatch.map((ele) => ele.data), dataBatch.map((ele) => ele.label), trainModel, j, batchesPerEpoch)
+      train(dataBatch.map((ele) => ele.data), dataBatch.map((ele) => ele.label), trainModel, j, batchesPerEpoch, trainSummaryWriter, iterations++)
     }
     if (validationLoader) {
       let loss = 0;


### PR DESCRIPTION
write the changes of loss and accuracy to the summary log which can be used for tensorboard.

This change will write the log to ~/.pipcook/components/{jobId}/model/summary

To use tensorbaord to show it, after installing tensorboard, just run

```
tensorboard --logdir=~/.pipcook/components/{jobId}/model/summary
```